### PR TITLE
fix(workflow): forcing a rollout restart when configmaps or secrets are updated 

### DIFF
--- a/.github/workflows/k8s-apply-sub.yaml
+++ b/.github/workflows/k8s-apply-sub.yaml
@@ -164,11 +164,11 @@ jobs:
               NEW_GENERATION=$(kubectl get deployment "$MICROSERVICE_FULLNAME" -n "$K8S_NAMESPACE" -o jsonpath='{.metadata.generation}')
               echo "::info::INFO - New generation for deployment $MICROSERVICE_FULLNAME: $NEW_GENERATION"
 
-              if ! ["$GENERATION" -eq "$NEW_GENERATION" ]; then
-                echo "::info::INFO - Generations for deployment $MICROSERVICE_FULLNAME are different. Forcing a rollout restart."
+              if ["$GENERATION" -eq "$NEW_GENERATION" ]; then
+                echo "::info::INFO - Generations for deployment $MICROSERVICE_FULLNAME are equals. Forcing a rollout restart."
                 kubectl rollout restart -n "$K8S_NAMESPACE" "deployment/$MICROSERVICE_FULLNAME"
               else
-                echo "::info::INFO - Generations for deployment $MICROSERVICE_FULLNAME are equals. No force restart needed."
+                echo "::info::INFO - Generations for deployment $MICROSERVICE_FULLNAME are different. No force restart needed."
               fi
 
             else

--- a/.github/workflows/k8s-apply-sub.yaml
+++ b/.github/workflows/k8s-apply-sub.yaml
@@ -155,8 +155,30 @@ jobs:
           # Check if the force rollout flag is true
           if [ "$FORCE_ROLLOUT" = true ]; then
             echo "::info::INFO - Force rollout restart requested $MICROSERVICE_FULLNAME."
+            
+            # Check if a rollout is already in progress
             if ! kubectl rollout status -n "$K8S_NAMESPACE" "deployment/$MICROSERVICE_FULLNAME" --watch=false >/dev/null 2>&1; then
-              echo "::info::INFO - Rollout already active for $MICROSERVICE_FULLNAME. No force restart needed."
+              echo "::info::INFO - Rollout already active for $MICROSERVICE_FULLNAME. Checking Pods status."
+
+              # Get the status of all Pods
+              PODS_STATUS=$(kubectl get pods -n "$K8S_NAMESPACE" -l app="$MICROSERVICE_FULLNAME" -o jsonpath='{.items[*].status.phase}')
+              PODS_ERROR=false
+
+              # Check if any Pod is in error state
+              for STATUS in $PODS_STATUS; do
+                if [ "$STATUS" == "Error" ] || [ "$STATUS" == "CrashLoopBackOff" ]; then
+                  PODS_ERROR=true
+                  break
+                fi
+              done
+
+              # Force rollout restart if any Pod is in error state
+              if [ "$PODS_ERROR" = true ]; then
+                echo "::info::INFO - At least one Pod is in error state in the active rollout. Forcing a rollout restart."
+                kubectl rollout restart -n "$K8S_NAMESPACE" "deployment/$MICROSERVICE_FULLNAME"
+              else
+                echo "::info::INFO - No Pods in error state. No force restart needed."
+              fi
             else
               echo "INFO - No rollout in progress, forcing a rollout restart."
               kubectl rollout restart -n "$K8S_NAMESPACE" "deployment/$MICROSERVICE_FULLNAME"

--- a/.github/workflows/k8s-apply-sub.yaml
+++ b/.github/workflows/k8s-apply-sub.yaml
@@ -137,14 +137,11 @@ jobs:
           TIMEOUT="${TIMEOUT_SECONDS}s"
 
           export PROJECT_DIR=$(pwd)
-          $SCRIPTS_FOLDER/helmTemplate-svc-single.sh --debug -e ${{ inputs.environment }} -m $MICROSERVICE_NAME -i $PROJECT_DIR/commons/${{ inputs.environment }}/images.yaml --output console > template.yaml
+          $SCRIPTS_FOLDER/helmTemplate-svc-single.sh --debug -e ${{ inputs.environment }} -m $MICROSERVICE_NAME -i $PROJECT_DIR/commons/${{ inputs.environment }}/images.yaml --dry-run --output console > template.yaml
 
           K8S_NAMESPACE=$(cat template.yaml | yq 'select(.kind == "Deployment") | .metadata.namespace')
           MICROSERVICE_FULLNAME=$(cat template.yaml | yq 'select(.kind == "Deployment") | .metadata.name')
           
-          GENERATION=$(kubectl get deployment "$MICROSERVICE_FULLNAME" -n "$K8S_NAMESPACE" -o jsonpath='{.metadata.generation}')
-          echo "::info::INFO - Current generation for deployment $MICROSERVICE_FULLNAME: $GENERATION"
-
           echo "INFO - Apply changes for $MICROSERVICE_FULLNAME."
           "$SCRIPTS_FOLDER/kubectlApply-svc-single-standalone.sh" --debug --skip-dep --environment "$K8S_NAMESPACE" -m "$MICROSERVICE_NAME" -i $PROJECT_DIR/commons/$K8S_NAMESPACE/images.yaml --output console
 
@@ -159,18 +156,7 @@ jobs:
           if [ "$FORCE_ROLLOUT" = true ]; then
             echo "::info::INFO - Force rollout restart requested $MICROSERVICE_FULLNAME."
             if ! kubectl rollout status -n "$K8S_NAMESPACE" "deployment/$MICROSERVICE_FULLNAME" --watch=false >/dev/null 2>&1; then
-              echo "::info::INFO - Rollout already active for $MICROSERVICE_FULLNAME."
-
-              NEW_GENERATION=$(kubectl get deployment "$MICROSERVICE_FULLNAME" -n "$K8S_NAMESPACE" -o jsonpath='{.metadata.generation}')
-              echo "::info::INFO - New generation for deployment $MICROSERVICE_FULLNAME: $NEW_GENERATION"
-
-              if ["$GENERATION" -eq "$NEW_GENERATION" ]; then
-                echo "::info::INFO - Generations for deployment $MICROSERVICE_FULLNAME are equals. Forcing a rollout restart."
-                kubectl rollout restart -n "$K8S_NAMESPACE" "deployment/$MICROSERVICE_FULLNAME"
-              else
-                echo "::info::INFO - Generations for deployment $MICROSERVICE_FULLNAME are different. No force restart needed."
-              fi
-
+              echo "::info::INFO - Rollout already active for $MICROSERVICE_FULLNAME. No force restart needed."
             else
               echo "INFO - No rollout in progress, forcing a rollout restart."
               kubectl rollout restart -n "$K8S_NAMESPACE" "deployment/$MICROSERVICE_FULLNAME"

--- a/.github/workflows/k8s-apply-sub.yaml
+++ b/.github/workflows/k8s-apply-sub.yaml
@@ -142,6 +142,9 @@ jobs:
           K8S_NAMESPACE=$(cat template.yaml | yq 'select(.kind == "Deployment") | .metadata.namespace')
           MICROSERVICE_FULLNAME=$(cat template.yaml | yq 'select(.kind == "Deployment") | .metadata.name')
           
+          GENERATION=$(kubectl get deployment "$MICROSERVICE_FULLNAME" -n "$K8S_NAMESPACE" -o jsonpath='{.metadata.generation}')
+          echo "::info::INFO - Current generation for deployment $MICROSERVICE_FULLNAME: $GENERATION"
+
           echo "INFO - Apply changes for $MICROSERVICE_FULLNAME."
           "$SCRIPTS_FOLDER/kubectlApply-svc-single-standalone.sh" --debug --skip-dep --environment "$K8S_NAMESPACE" -m "$MICROSERVICE_NAME" -i $PROJECT_DIR/commons/$K8S_NAMESPACE/images.yaml --output console
 
@@ -155,30 +158,19 @@ jobs:
           # Check if the force rollout flag is true
           if [ "$FORCE_ROLLOUT" = true ]; then
             echo "::info::INFO - Force rollout restart requested $MICROSERVICE_FULLNAME."
-            
-            # Check if a rollout is already in progress
             if ! kubectl rollout status -n "$K8S_NAMESPACE" "deployment/$MICROSERVICE_FULLNAME" --watch=false >/dev/null 2>&1; then
-              echo "::info::INFO - Rollout already active for $MICROSERVICE_FULLNAME. Checking Pods status."
+              echo "::info::INFO - Rollout already active for $MICROSERVICE_FULLNAME."
 
-              # Get the status of all Pods
-              PODS_STATUS=$(kubectl get pods -n "$K8S_NAMESPACE" -l app="$MICROSERVICE_FULLNAME" -o jsonpath='{.items[*].status.phase}')
-              PODS_ERROR=false
+              NEW_GENERATION=$(kubectl get deployment "$MICROSERVICE_FULLNAME" -n "$K8S_NAMESPACE" -o jsonpath='{.metadata.generation}')
+              echo "::info::INFO - New generation for deployment $MICROSERVICE_FULLNAME: $NEW_GENERATION"
 
-              # Check if any Pod is in error state
-              for STATUS in $PODS_STATUS; do
-                if [ "$STATUS" == "Error" ] || [ "$STATUS" == "CrashLoopBackOff" ]; then
-                  PODS_ERROR=true
-                  break
-                fi
-              done
-
-              # Force rollout restart if any Pod is in error state
-              if [ "$PODS_ERROR" = true ]; then
-                echo "::info::INFO - At least one Pod is in error state in the active rollout. Forcing a rollout restart."
+              if ! ["$GENERATION" -eq "$NEW_GENERATION" ]; then
+                echo "::info::INFO - Generations for deployment $MICROSERVICE_FULLNAME are different. Forcing a rollout restart."
                 kubectl rollout restart -n "$K8S_NAMESPACE" "deployment/$MICROSERVICE_FULLNAME"
               else
-                echo "::info::INFO - No Pods in error state. No force restart needed."
+                echo "::info::INFO - Generations for deployment $MICROSERVICE_FULLNAME are equals. No force restart needed."
               fi
+
             else
               echo "INFO - No rollout in progress, forcing a rollout restart."
               kubectl rollout restart -n "$K8S_NAMESPACE" "deployment/$MICROSERVICE_FULLNAME"

--- a/.github/workflows/k8s-apply-sub.yaml
+++ b/.github/workflows/k8s-apply-sub.yaml
@@ -143,7 +143,7 @@ jobs:
           MICROSERVICE_FULLNAME=$(cat template.yaml | yq 'select(.kind == "Deployment") | .metadata.name')
           
           echo "INFO - Apply changes for $MICROSERVICE_FULLNAME."
-          "$SCRIPTS_FOLDER/kubectlApply-svc-single-standalone.sh" --debug --skip-dep --environment "$K8S_NAMESPACE" -m "$MICROSERVICE_NAME" -i $PROJECT_DIR/commons/$K8S_NAMESPACE/images.yaml --output console
+          "$SCRIPTS_FOLDER/kubectlApply-svc-single-standalone.sh" --force-template-configmap-first --debug --skip-dep --environment "$K8S_NAMESPACE" -m "$MICROSERVICE_NAME" -i $PROJECT_DIR/commons/$K8S_NAMESPACE/images.yaml --output console
 
           DESIRED_REPLICAS=$(kubectl get deployment "$MICROSERVICE_FULLNAME" -n "$K8S_NAMESPACE" -o jsonpath='{.spec.replicas}')
           echo "INFO - Desired replicas: $DESIRED_REPLICAS"

--- a/.github/workflows/k8s-apply-sub.yaml
+++ b/.github/workflows/k8s-apply-sub.yaml
@@ -143,7 +143,7 @@ jobs:
           MICROSERVICE_FULLNAME=$(cat template.yaml | yq 'select(.kind == "Deployment") | .metadata.name')
           
           echo "INFO - Apply changes for $MICROSERVICE_FULLNAME."
-          "$SCRIPTS_FOLDER/kubectlApply-svc-single-standalone.sh" --force-template-configmap-first --debug --skip-dep --environment "$K8S_NAMESPACE" -m "$MICROSERVICE_NAME" -i $PROJECT_DIR/commons/$K8S_NAMESPACE/images.yaml --output console
+          "$SCRIPTS_FOLDER/kubectlApply-svc-single-standalone.sh" --debug --skip-dep --environment "$K8S_NAMESPACE" -m "$MICROSERVICE_NAME" -i $PROJECT_DIR/commons/$K8S_NAMESPACE/images.yaml --output console
 
           DESIRED_REPLICAS=$(kubectl get deployment "$MICROSERVICE_FULLNAME" -n "$K8S_NAMESPACE" -o jsonpath='{.spec.replicas}')
           echo "INFO - Desired replicas: $DESIRED_REPLICAS"

--- a/.github/workflows/k8s-apply.yaml
+++ b/.github/workflows/k8s-apply.yaml
@@ -148,7 +148,7 @@ jobs:
     uses: ./.github/workflows/k8s-apply-sub.yaml
     with:
       environment: ${{ inputs.environment }}
-      timeout_seconds: ${{ vars.ROLLOUT_TIMEOUT_SECONDS || 600 }}
+      timeout_seconds: ${{ vars.ROLLOUT_TIMEOUT_SECONDS || 300 }}
 
   delete_runner:
     name: Delete Self-Hosted Runner

--- a/.github/workflows/k8s-apply.yaml
+++ b/.github/workflows/k8s-apply.yaml
@@ -148,7 +148,7 @@ jobs:
     uses: ./.github/workflows/k8s-apply-sub.yaml
     with:
       environment: ${{ inputs.environment }}
-      timeout_seconds: 180
+      timeout_seconds: ${{ vars.ROLLOUT_TIMEOUT_SECONDS || 600 }}
 
   delete_runner:
     name: Delete Self-Hosted Runner

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -5,7 +5,7 @@ type: application
 version: 0.0.1
 dependencies:
   - name: interop-eks-microservice-chart
-    version: 1.13.2
+    version: 1.13.2 #TO_UPDATE
     repository: "https://pagopa.github.io/interop-eks-microservice-chart"
   - name: interop-eks-cronjob-chart
     version: 1.5.1

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -5,7 +5,7 @@ type: application
 version: 0.0.1
 dependencies:
   - name: interop-eks-microservice-chart
-    version: 1.13.2 #TO_UPDATE
+    version: 1.20.0
     repository: "https://pagopa.github.io/interop-eks-microservice-chart"
   - name: interop-eks-cronjob-chart
     version: 1.5.1

--- a/microservices/jwt-audit-analytics-writer/dev-analytics/values.yaml
+++ b/microservices/jwt-audit-analytics-writer/dev-analytics/values.yaml
@@ -13,6 +13,7 @@ configmap:
   BATCH_SIZE: 500
 
 deployment:
+  enableRollingUpdate: true
   flywayInitContainer:
     create: true
     version: "11.4.0"

--- a/microservices/jwt-audit-analytics-writer/dev-analytics/values.yaml
+++ b/microservices/jwt-audit-analytics-writer/dev-analytics/values.yaml
@@ -13,7 +13,7 @@ configmap:
   BATCH_SIZE: 500
 
 deployment:
-  enableRollingUpdate: true
+  enableRolloutAnnotations: true
   flywayInitContainer:
     create: true
     version: "11.4.0"


### PR DESCRIPTION
This PR adds the `--dry-run` option when running the `helmTemplate-svc-single.sh` script in the pipeline.
This option helps in forcing a rollout restart when a referenced configmap or secret is updated.

Related PRs:
- [#27](https://github.com/pagopa/interop-infra-commons/pull/27) on interop-infra-commons
- [#34](https://github.com/pagopa/interop-eks-microservice-chart/pull/34) on interop-eks-microservice-chart