### PR TITLE
Edited the service_elapsed view

### DIFF
--- a/views/application/R__application_01_service_elapsed_mv.sql
+++ b/views/application/R__application_01_service_elapsed_mv.sql
@@ -9,10 +9,5 @@ select
 DATE_PART(year, (CONVERT_TIMEZONE('Europe/Rome',  TIMESTAMP 'epoch' + (bra.timestamp / 1000) * INTERVAL '1 second'))) as year, 
 DATE_PART(month, (CONVERT_TIMEZONE('Europe/Rome',  TIMESTAMP 'epoch' + (bra.timestamp / 1000) * INTERVAL '1 second'))) as month, 
 DATE_PART(day, (CONVERT_TIMEZONE('Europe/Rome',  TIMESTAMP 'epoch' + (bra.timestamp / 1000) * INTERVAL '1 second'))) as day, 
-bra.service, bra.endpoint, bra.http_method, AVG(era."timestamp" - bra."timestamp") as ms_avg_elapsed 
+bra.service, bra.endpoint, bra.http_method, era."timestamp" - bra."timestamp" as ms_avg_elapsed 
 from interop_dev.application.begin_request_audit bra inner join interop_dev.application.end_request_audit era on bra.span_id = era.span_id
-group by 
-DATE_PART(year, (CONVERT_TIMEZONE('Europe/Rome',  TIMESTAMP 'epoch' + (bra.timestamp / 1000) * INTERVAL '1 second'))), 
-DATE_PART(month, (CONVERT_TIMEZONE('Europe/Rome',  TIMESTAMP 'epoch' + (bra.timestamp / 1000) * INTERVAL '1 second'))), 
-DATE_PART(day, (CONVERT_TIMEZONE('Europe/Rome',  TIMESTAMP 'epoch' + (bra.timestamp / 1000) * INTERVAL '1 second'))), 
-bra.service, bra.endpoint, bra.http_method;


### PR DESCRIPTION
Edited the service_elapsed view in order to remove the group by clause to have the chance to drill down data for single service call - before was grouped by day with the elapsed time avg