### PR TITLE
fix: edit attribute in kpi-domains-readmodel-checker values.yaml

### DIFF
--- a/jobs/kpi-domains-readmodel-checker/dev-analytics/values.yaml
+++ b/jobs/kpi-domains-readmodel-checker/dev-analytics/values.yaml
@@ -4,7 +4,7 @@ cronjob:
   schedule: "0 2 * * *"
   timeZone: "Europe/Rome"
   failedJobsHistoryLimit: 2
-  successfulJobsHistoryLimit: 0
+  successfulJobsHistoryLimit: 1
   restartPolicy: OnFailure
 
   envFromConfigmaps:


### PR DESCRIPTION
After the cronjob has completed, it can be helpful to keep at least the last run in the history to check the logs.  