### PR TITLE
feature(mv_refresh): stored procedure and tables needed by MV refresher lambda

### DIFF
--- a/views/procedures/last_mv_refresh_info/R__procedures_01_list_need_refresh_views.sql
+++ b/views/procedures/last_mv_refresh_info/R__procedures_01_list_need_refresh_views.sql
@@ -1,0 +1,46 @@
+CREATE SCHEMA IF NOT EXISTS sub_views;
+
+GRANT USAGE ON SCHEMA sub_views TO GROUP readonly_group;
+
+
+CREATE OR REPLACE PROCEDURE sub_views.list_need_refresh_views(schema_list IN VARCHAR(MAX) )
+AS $$
+BEGIN
+  
+  drop table if exists list_need_refresh_views_results;
+  
+  create temporary table list_need_refresh_views_results AS 
+  (
+    with
+        views_to_refresh as (
+          select
+            trim(schema_name) as mv_schema,
+            trim(name) as mv_name,
+            cast(REGEXP_REPLACE( name, 'mv_([0-9][0-9]).*', '$1') as integer) as mv_level 
+          from 
+            SVV_MV_INFO
+          where
+              is_stale = 't'
+            and 
+              -- Split string to arrays and use them as second parameter of an in operator is too complex
+              -- I use some string matching
+              -- example ',views,sub_views' with no spaces
+	          quote_ident(',' + regexp_replace( schema_list, '\\s', '')  + ',') 
+              like
+              ('%,' + schema_name + ',%')
+        )
+      select
+        mv_schema,
+        mv_name,
+        mv_level
+      from
+        views_to_refresh
+  );
+  
+  GRANT SELECT ON list_need_refresh_views_results to ${NAMESPACE}_mv_refresher_user;
+END;
+$$ LANGUAGE plpgsql
+SECURITY DEFINER;
+
+GRANT EXECUTE ON procedure sub_views.list_need_refresh_views(schema_list IN VARCHAR(MAX) ) 
+      TO ${NAMESPACE}_mv_refresher_user;

--- a/views/procedures/last_mv_refresh_info/R__procedures_01_refresh_materialized_view.sql
+++ b/views/procedures/last_mv_refresh_info/R__procedures_01_refresh_materialized_view.sql
@@ -1,0 +1,31 @@
+CREATE SCHEMA IF NOT EXISTS sub_views;
+
+GRANT USAGE ON SCHEMA sub_views TO GROUP readonly_group;
+
+
+CREATE OR REPLACE PROCEDURE sub_views.refresh_materialized_view(schema_name VARCHAR, view_name VARCHAR)
+AS $$
+DECLARE
+  view_full_name VARCHAR(MAX);
+  sql_command VARCHAR(MAX);
+BEGIN
+  -- Build the REFRESH command string safely using quote_ident to prevent SQL injection
+  view_full_name := quote_ident(schema_name) || '.' || quote_ident(view_name);
+  sql_command := 'REFRESH MATERIALIZED VIEW ' || view_full_name || ';';
+  
+  -- Provide an informational message about what is being refreshed
+  RAISE INFO 'Attempting to run command: %', sql_command;
+  
+  -- Execute the dynamically created command
+  EXECUTE sql_command;
+  
+  RAISE INFO 'Successfully refreshed materialized view: %', view_full_name;
+  
+END;
+$$ LANGUAGE plpgsql
+SECURITY DEFINER;
+
+GRANT EXECUTE ON procedure sub_views.refresh_materialized_view(schema_name VARCHAR, view_name VARCHAR) 
+      TO ${NAMESPACE}_mv_refresher_user
+;
+

--- a/views/procedures/last_mv_refresh_info/R__procedures_01_update_last_mv_refresh_info.sql
+++ b/views/procedures/last_mv_refresh_info/R__procedures_01_update_last_mv_refresh_info.sql
@@ -1,0 +1,69 @@
+CREATE SCHEMA IF NOT EXISTS sub_views;
+
+GRANT USAGE ON SCHEMA sub_views TO GROUP readonly_group;
+
+
+CREATE OR REPLACE PROCEDURE sub_views.update_last_mv_refresh_info(
+  schema_list IN VARCHAR(MAX)
+)
+AS $$
+BEGIN
+  -- Remove all lines ...
+  delete from views.last_mv_refresh_info;
+  
+  -- ... and refill in the same transaction.
+  insert into views.last_mv_refresh_info
+  (
+	with 
+	  refresh_events as (
+	    select 
+	      database_name,
+	      schema_name,
+	      mv_name,
+	      refresh_type,
+	      status,
+	      start_time,
+	      end_time,
+	      duration,
+	      ROW_NUMBER() over ( partition by database_name, schema_name, mv_name order by start_time desc ) as nr
+	    from
+	      SYS_MV_REFRESH_HISTORY
+	    where 
+	        database_name = current_database()
+	      and
+              -- Split string to arrays and use them as second parameter of an in operator is too complex
+              -- I use some string matching
+              -- example ',views,sub_views' with no spaces
+	          quote_ident(',' + regexp_replace( schema_list, '\\s', '')  + ',') 
+              like
+              ('%,' + schema_name + ',%')
+	      and 
+	        (
+	            status like 'Refresh successfully%'
+	          or
+	            status like 'Refresh partially updated%'
+	          or
+	            status like '%already updated%'
+	        )
+	  )
+	select
+	  database_name,
+	  schema_name,
+	  mv_name,
+	  refresh_type,
+	  start_time,
+	  end_time,
+      duration
+	from
+	  refresh_events
+	where 
+	  nr = 1
+  );
+END;
+$$ LANGUAGE plpgsql
+SECURITY DEFINER;
+
+
+GRANT EXECUTE ON procedure sub_views.update_last_mv_refresh_info( schema_list IN VARCHAR(MAX) ) 
+      TO ${NAMESPACE}_mv_refresher_user;
+

--- a/views/procedures/last_mv_refresh_info/V0__grant_00_schemas_rights_to_mv_refresher_user.sql
+++ b/views/procedures/last_mv_refresh_info/V0__grant_00_schemas_rights_to_mv_refresher_user.sql
@@ -1,0 +1,9 @@
+
+-- Grant needed access to a user dedicated to call this procedure,
+--  that user need to be altered 'WITH SYSLOG ACCESS UNRESTRICTED'
+CREATE SCHEMA IF NOT EXISTS views;
+GRANT USAGE ON SCHEMA views TO ${NAMESPACE}_mv_refresher_user;
+
+CREATE SCHEMA IF NOT EXISTS sub_views;
+GRANT USAGE ON SCHEMA sub_views TO ${NAMESPACE}_mv_refresher_user;
+

--- a/views/procedures/last_mv_refresh_info/V1__table_00_last_mv_refresh_info.sql
+++ b/views/procedures/last_mv_refresh_info/V1__table_00_last_mv_refresh_info.sql
@@ -1,0 +1,17 @@
+CREATE SCHEMA IF NOT EXISTS views;
+
+GRANT USAGE ON SCHEMA views TO GROUP readonly_group;
+GRANT USAGE ON SCHEMA views TO ${NAMESPACE}_quicksight_user;
+
+
+CREATE TABLE IF NOT EXISTS views.last_mv_refresh_info (
+  database_name VARCHAR(250),
+  schema_name VARCHAR(250),
+  mv_name VARCHAR(250),
+  refresh_type VARCHAR(20),
+  start_time timestamp,
+  end_time timestamp,
+  duration bigint
+);
+
+GRANT SELECT ON TABLE views.last_mv_refresh_info TO ${NAMESPACE}_quicksight_user;


### PR DESCRIPTION
Our goal is to have a parallel refresh of redshift materialized views scheduled every some minutes.
- We want to control the refesh mecanism with EventBridge, node-lambda and RedShift-data-API
  Node lambda is useful to have a well known and flexible way to handle parallelism.
- We want to use a "not privileged", "not materialized view owner" user.
- We want to expose the "last refresh timestamp" of every materailized view to the quicksight user