### PR TITLE
refactor(kpi,PIN-6997): performance optimization of IPs-by-client-view

### DIFF
--- a/views/application/R__application_mv_00_client_tenant_authserver_ips__latest_ts.sql
+++ b/views/application/R__application_mv_00_client_tenant_authserver_ips__latest_ts.sql
@@ -4,8 +4,4 @@ GRANT USAGE ON SCHEMA sub_views TO GROUP readonly_group;
 
 DROP MATERIALIZED VIEW IF EXISTS sub_views.mv_00_client_tenant_authserver_ips__latest_ts CASCADE;
 
-CREATE MATERIALIZED VIEW sub_views.mv_00_client_tenant_authserver_ips__latest_ts AUTO REFRESH NO as
-select gta.client_id, bra.requester_ip_address ips, max(bra.timestamp) as latest_ts from application.begin_request_audit bra
-inner join jwt.generated_token_audit gta on bra.correlation_id = gta.correlation_id
-where bra.service = 'authorization-server'
-group by gta.client_id, bra.requester_ip_address
+-- REMOVED: unnecessary after refactoring

--- a/views/application/R__application_mv_00_client_tenant_authserver_ips__main.sql
+++ b/views/application/R__application_mv_00_client_tenant_authserver_ips__main.sql
@@ -5,12 +5,17 @@ GRANT USAGE ON SCHEMA sub_views TO GROUP readonly_group;
 DROP MATERIALIZED VIEW IF EXISTS sub_views.mv_00_client_tenant_authserver_ips__main CASCADE;
 
 CREATE MATERIALIZED VIEW sub_views.mv_00_client_tenant_authserver_ips__main AUTO REFRESH NO as
-select t."name" tenant_name , gta.client_id client_id, c."name" client_name  , bra.requester_ip_address ips 
-from application.begin_request_audit bra
-inner join jwt.generated_token_audit gta on bra.correlation_id = gta.correlation_id
-inner join domains.client c on c.id = gta.client_id
-inner join domains.client_purpose cp  on cp.client_id = c.id
-inner join domains.purpose p on p.id = cp.purpose_id 
-inner join domains.tenant t on t.id = p.consumer_id
-where bra.service = 'authorization-server'
-group by t."name" , gta.client_id, c."name" , bra.requester_ip_address
+select
+  gta.client_id,
+  bra.requester_ip_address ips,
+  max(bra.timestamp) as latest_ts,
+  min(bra.timestamp) as oldest_ts
+from
+  application.begin_request_audit bra
+  inner join jwt.generated_token_audit gta
+          on bra.correlation_id = gta.correlation_id
+where
+  bra.service = 'authorization-server'
+group by
+  gta.client_id, bra.requester_ip_address
+;

--- a/views/application/R__application_mv_00_client_tenant_authserver_ips__oldest_ts.sql
+++ b/views/application/R__application_mv_00_client_tenant_authserver_ips__oldest_ts.sql
@@ -4,8 +4,4 @@ GRANT USAGE ON SCHEMA sub_views TO GROUP readonly_group;
 
 DROP MATERIALIZED VIEW IF EXISTS sub_views.mv_00_client_tenant_authserver_ips__oldest_ts CASCADE;
 
-CREATE MATERIALIZED VIEW sub_views.mv_00_client_tenant_authserver_ips__oldest_ts AUTO REFRESH NO as
-select gta.client_id, bra.requester_ip_address ips, min(bra.timestamp) as oldest_ts from application.begin_request_audit bra
-inner join jwt.generated_token_audit gta on bra.correlation_id = gta.correlation_id
-where bra.service = 'authorization-server'
-group by gta.client_id, bra.requester_ip_address
+-- REMOVED: unnecessary after refactoring

--- a/views/application/R__application_mv_01_client_tenant_authserver_ips.sql
+++ b/views/application/R__application_mv_01_client_tenant_authserver_ips.sql
@@ -6,10 +6,17 @@ GRANT USAGE ON SCHEMA views TO ${NAMESPACE}_quicksight_user;
 DROP MATERIALIZED VIEW IF EXISTS views.mv_01_client_tenant_authserver_ips CASCADE;
 
 CREATE MATERIALIZED VIEW views.mv_01_client_tenant_authserver_ips AS 
-select  main.tenant_name, main.client_name, main.ips, latest_ts.latest_ts, oldest_ts.oldest_ts from sub_views.mv_00_client_tenant_authserver_ips__main main
-inner join sub_views.mv_00_client_tenant_authserver_ips__latest_ts latest_ts
-on main.client_id = latest_ts.client_id and main.ips = latest_ts.ips
-inner join sub_views.mv_00_client_tenant_authserver_ips__oldest_ts oldest_ts
-on main.client_id = oldest_ts.client_id and main.ips = oldest_ts.ips;
+select
+  t."name" tenant_name,
+  c."name" client_name,
+  main.client_id,
+  main.ips,
+  main.latest_ts,
+  main.oldest_ts
+from
+  sub_views.mv_00_client_tenant_authserver_ips__main main
+  inner join domains.client c on c.id = main.client_id
+  inner join domains.tenant t on t.id = c.consumer_id
+;
 
 GRANT SELECT ON TABLE views.mv_01_client_tenant_authserver_ips TO ${NAMESPACE}_quicksight_user;

--- a/views/application/R__application_mv_01_client_tenant_authserver_ips.sql
+++ b/views/application/R__application_mv_01_client_tenant_authserver_ips.sql
@@ -5,7 +5,7 @@ GRANT USAGE ON SCHEMA views TO ${NAMESPACE}_quicksight_user;
 
 DROP MATERIALIZED VIEW IF EXISTS views.mv_01_client_tenant_authserver_ips CASCADE;
 
-CREATE MATERIALIZED VIEW views.mv_01_client_tenant_authserver_ips AS 
+CREATE MATERIALIZED VIEW views.mv_01_client_tenant_authserver_ips AS
 select
   t."name" tenant_name,
   c."name" client_name,
@@ -17,6 +17,10 @@ from
   sub_views.mv_00_client_tenant_authserver_ips__main main
   inner join domains.client c on c.id = main.client_id
   inner join domains.tenant t on t.id = c.consumer_id
+  --inner join domains.client c on c.id = main.client_id
+  --inner join domains.client_purpose cp  on cp.client_id = c.id
+  --inner join domains.purpose p on p.id = cp.purpose_id
+  --inner join domains.tenant t on t.id = p.consumer_id
 ;
 
 GRANT SELECT ON TABLE views.mv_01_client_tenant_authserver_ips TO ${NAMESPACE}_quicksight_user;

--- a/views/application/auth_server_usage/R__application_mv_01_auth_usage__data__last_calls.sql
+++ b/views/application/auth_server_usage/R__application_mv_01_auth_usage__data__last_calls.sql
@@ -6,9 +6,9 @@ GRANT USAGE ON SCHEMA views TO ${NAMESPACE}_quicksight_user;
 DROP MATERIALIZED VIEW IF EXISTS views.mv_01_auth_usage__data__last_calls CASCADE;
 
 -- Repeat the same query with three time different time period 
---  Last 5 entire minutes. At 14:05:06 this interval is [ 14:00:00, 14:05:00 [
 --  Last 15 entire minutes. At 14:05:06 this interval is [ 13:50:00, 14:05:00 [
 --  Last 30 entire minutes. At 14:05:06 this interval is [ 13:35:00, 14:05:00 [
+--  Last 45 entire minutes. At 14:05:06 this interval is [ 13:20:00, 14:05:00 [
 -- N.B.: this view in not an "incremental refresh one" it will be recomputed at 
 --       every "refresh lambda" execution
 CREATE MATERIALIZED VIEW views.mv_01_auth_usage__data__last_calls as
@@ -22,31 +22,10 @@ CREATE MATERIALIZED VIEW views.mv_01_auth_usage__data__last_calls as
     sum( quantity_4xx ) as quantity_4xx,
     sum( total_4xx_execution_time ) as total_4xx_execution_time,
     sum( quantity_5xx ) as quantity_5xx,
-    date_add('minute', -1 * 5, date_trunc( 'minute', getdate() ) ) as from_ts,
-    date_trunc( 'minute', getdate() ) as to_ts,
-    5 as period_length_minutes
-  from 
-    views.mv_00_auth_usage__data__calls
-  where 
-    minute_slot between date_add('minute', -1 * 5, date_trunc( 'minute', getdate() ) )
-                    and date_trunc( 'minute', getdate() )
-  group by 
-    consumer_name,
-    client_name
-UNION ALL 
-  select 
-    consumer_name,
-    client_name,
-    sum( calls_quantity ) as calls_quantity,
-    sum( total_execution_time ) as total_execution_time,
-    sum( quantity_2xx ) as quantity_2xx,
-    sum( total_2xx_execution_time ) as total_2xx_execution_time,
-    sum( quantity_4xx ) as quantity_4xx,
-    sum( total_4xx_execution_time ) as total_4xx_execution_time,
-    sum( quantity_5xx ) as quantity_5xx,
     date_add('minute', -1 * 15, date_trunc( 'minute', getdate() ) ) as from_ts,
     date_trunc( 'minute', getdate() ) as to_ts,
-    15 as period_length_minutes
+    15 as period_length_minutes,
+    max(minute_slot) as last_minute_with_requests
   from 
     views.mv_00_auth_usage__data__calls
   where 
@@ -68,11 +47,35 @@ UNION ALL
     sum( quantity_5xx ) as quantity_5xx,
     date_add('minute', -1 * 30, date_trunc( 'minute', getdate() ) ) as from_ts,
     date_trunc( 'minute', getdate() ) as to_ts,
-    30 as period_length_minutes
+    30 as period_length_minutes,
+    max(minute_slot) as last_minute_with_requests
   from 
     views.mv_00_auth_usage__data__calls
   where 
     minute_slot between date_add('minute', -1 * 30, date_trunc( 'minute', getdate() ) )
+                    and date_trunc( 'minute', getdate() )
+  group by 
+    consumer_name,
+    client_name
+UNION ALL 
+  select 
+    consumer_name,
+    client_name,
+    sum( calls_quantity ) as calls_quantity,
+    sum( total_execution_time ) as total_execution_time,
+    sum( quantity_2xx ) as quantity_2xx,
+    sum( total_2xx_execution_time ) as total_2xx_execution_time,
+    sum( quantity_4xx ) as quantity_4xx,
+    sum( total_4xx_execution_time ) as total_4xx_execution_time,
+    sum( quantity_5xx ) as quantity_5xx,
+    date_add('minute', -1 * 45, date_trunc( 'minute', getdate() ) ) as from_ts,
+    date_trunc( 'minute', getdate() ) as to_ts,
+    45 as period_length_minutes,
+    max(minute_slot) as last_minute_with_requests
+  from 
+    views.mv_00_auth_usage__data__calls
+  where 
+    minute_slot between date_add('minute', -1 * 45, date_trunc( 'minute', getdate() ) )
                     and date_trunc( 'minute', getdate() )
   group by 
     consumer_name,

--- a/views/application/auth_server_usage/R__application_mv_01_auth_usage__data__last_calls.sql
+++ b/views/application/auth_server_usage/R__application_mv_01_auth_usage__data__last_calls.sql
@@ -9,7 +9,7 @@ DROP MATERIALIZED VIEW IF EXISTS views.mv_01_auth_usage__data__last_calls CASCAD
 --  Last 15 entire minutes. At 14:05:06 this interval is [ 13:50:00, 14:05:00 [
 --  Last 30 entire minutes. At 14:05:06 this interval is [ 13:35:00, 14:05:00 [
 --  Last 45 entire minutes. At 14:05:06 this interval is [ 13:20:00, 14:05:00 [
--- N.B.: this view in not an "incremental refresh one" it will be recomputed at 
+-- N.B.: this view is not an "incremental refresh one" it will be recomputed at 
 --       every "refresh lambda" execution
 CREATE MATERIALIZED VIEW views.mv_01_auth_usage__data__last_calls as
   select 


### PR DESCRIPTION
## Pull request overview

This PR implements a performance optimization for the IPs-by-client-view (PIN-6997) by consolidating materialized views and adjusting time window parameters for auth server usage tracking.

**Changes:**
- Consolidated three separate IP tracking views (main, latest_ts, oldest_ts) into a single view with computed aggregations
- Refactored client-tenant join to use the standard direct consumer_id relationship instead of indirect path through purpose tables
- Adjusted auth usage time windows from 5/15/30 minutes to 15/30/45 minutes and added last_minute_with_requests tracking
