### PR TITLE
fix(kpi): remove not essentials materialized views and fair, best effort, refresh.

### DIFF
--- a/views/application/auth_server_usage/R__application_mv_00_auth_usage__checks__calls_jwt_multi_relation.sql
+++ b/views/application/auth_server_usage/R__application_mv_00_auth_usage__checks__calls_jwt_multi_relation.sql
@@ -4,18 +4,18 @@ GRANT USAGE ON SCHEMA sub_views TO GROUP readonly_group;
 
 DROP MATERIALIZED VIEW IF EXISTS sub_views.mv_00_auth_usage__checks__calls_jwt_multi_relation CASCADE;
 
-CREATE MATERIALIZED VIEW sub_views.mv_00_auth_usage__checks__calls_jwt_multi_relation AUTO REFRESH NO as
-select
-  gta.correlation_id,
-  (case when count( gta.jwt_id ) > 1 then 1 else 0 end ) as calls_associated_to_more_than_one_token,
-  -- Bucket time by minutes and remove the millisecond factor from the epoch.
-  -- Get the time of the most recent call in the group
-  ((max(erasa.timestamp) / ( 60 * 1000 )) * 60) as epoch_of_the_second_when_the_minute_slot_is_started
--- If multiple token have the same correlation_id or multiple calls have the same correlation_id ...
-from 
-  jwt.generated_token_audit gta 
-  join application.end_request_auth_server_audit erasa on erasa.correlation_id = gta.correlation_id 
--- ... this group by group multiple records
-group by
-  gta.correlation_id
-;
+-- CREATE MATERIALIZED VIEW sub_views.mv_00_auth_usage__checks__calls_jwt_multi_relation AUTO REFRESH NO as
+-- select
+--   gta.correlation_id,
+--   (case when count( gta.jwt_id ) > 1 then 1 else 0 end ) as calls_associated_to_more_than_one_token,
+--   -- Bucket time by minutes and remove the millisecond factor from the epoch.
+--   -- Get the time of the most recent call in the group
+--   ((max(erasa.timestamp) / ( 60 * 1000 )) * 60) as epoch_of_the_second_when_the_minute_slot_is_started
+-- -- If multiple token have the same correlation_id or multiple calls have the same correlation_id ...
+-- from 
+--   jwt.generated_token_audit gta 
+--   join application.end_request_auth_server_audit erasa on erasa.correlation_id = gta.correlation_id 
+-- -- ... this group by group multiple records
+-- group by
+--   gta.correlation_id
+-- ;

--- a/views/application/auth_server_usage/R__application_mv_00_auth_usage__checks__calls_jwt_relation.sql
+++ b/views/application/auth_server_usage/R__application_mv_00_auth_usage__checks__calls_jwt_relation.sql
@@ -8,23 +8,23 @@ DROP MATERIALIZED VIEW IF EXISTS sub_views.mv_00_auth_usage__checks__calls_jwt_r
 -- This view also pin out the tokens that have null correlation_id.
 -- To use incremental refresh we can't use outer join. This query count the number of 
 -- token in a minute and the number of token related to a call in the same minute.
-CREATE MATERIALIZED VIEW sub_views.mv_00_auth_usage__checks__calls_jwt_relation AUTO REFRESH NO as
-select 
-  1 as token_issued,
-  ( case when gta.jwt_id is null then 1 else 0 end ) as token_issued_without_correlation_id,
-  0 as token_related_to_calls, 
-  -- Bucket time by minutes and remove the millisecond factor from the epoch.
-  ((gta.issued_at / ( 60 * 1000 )) * 60) as epoch_of_the_second_when_the_minute_slot_is_started
-from 
-  jwt.generated_token_audit gta 
-union all 
-select 
-  0 as token_issued,
-  0 as token_issued_without_correlation_id,
-  1 as token_related_to_calls, 
-  -- Bucket time by minutes and remove the millisecond factor from the epoch.
-  ((gta.issued_at / ( 60 * 1000 )) * 60) as epoch_of_the_second_when_the_minute_slot_is_started
-from 
-  jwt.generated_token_audit gta 
-  join application.end_request_auth_server_audit erasa on erasa.correlation_id = gta.correlation_id 
-;
+-- CREATE MATERIALIZED VIEW sub_views.mv_00_auth_usage__checks__calls_jwt_relation AUTO REFRESH NO as
+-- select 
+--   1 as token_issued,
+--   ( case when gta.jwt_id is null then 1 else 0 end ) as token_issued_without_correlation_id,
+--   0 as token_related_to_calls, 
+--   -- Bucket time by minutes and remove the millisecond factor from the epoch.
+--   ((gta.issued_at / ( 60 * 1000 )) * 60) as epoch_of_the_second_when_the_minute_slot_is_started
+-- from 
+--   jwt.generated_token_audit gta 
+-- union all 
+-- select 
+--   0 as token_issued,
+--   0 as token_issued_without_correlation_id,
+--   1 as token_related_to_calls, 
+--   -- Bucket time by minutes and remove the millisecond factor from the epoch.
+--   ((gta.issued_at / ( 60 * 1000 )) * 60) as epoch_of_the_second_when_the_minute_slot_is_started
+-- from 
+--   jwt.generated_token_audit gta 
+--   join application.end_request_auth_server_audit erasa on erasa.correlation_id = gta.correlation_id 
+-- ;

--- a/views/application/auth_server_usage/R__application_mv_01_auth_usage__checks__union.sql
+++ b/views/application/auth_server_usage/R__application_mv_01_auth_usage__checks__union.sql
@@ -4,29 +4,29 @@ GRANT USAGE ON SCHEMA sub_views TO GROUP readonly_group;
 
 DROP MATERIALIZED VIEW IF EXISTS sub_views.mv_01_auth_usage__checks__union CASCADE;
 
--- Based on "keep logic into the RedShift, not into QuickSight" tenant 
--- I choose to make the UNION of two different data set here. I need to 
--- work around the following limitations:
---  - Incremental refresh do not support `outer join` and
---    `epoch_of_the_second_when_the_minute_slot_is_started` is not guaranteed to be the 
---    same in both sub_views.
---  - Incremental refresh do not support `union all` and `group by` in the same view
-CREATE MATERIALIZED VIEW sub_views.mv_01_auth_usage__checks__union as
-select 
-  token_issued,
-  token_issued_without_correlation_id,
-  token_related_to_calls,
-  0 as calls_associated_to_more_than_one_token,
-  epoch_of_the_second_when_the_minute_slot_is_started
-from
-  sub_views.mv_00_auth_usage__checks__calls_jwt_relation
-union all
-select 
-  0 as token_issued,
-  0 as token_issued_without_correlation_id,
-  0 as token_related_to_calls,
-  calls_associated_to_more_than_one_token,
-  epoch_of_the_second_when_the_minute_slot_is_started
-from
-  sub_views.mv_00_auth_usage__checks__calls_jwt_multi_relation
-;
+-- -- Based on "keep logic into the RedShift, not into QuickSight" tenant 
+-- -- I choose to make the UNION of two different data set here. I need to 
+-- -- work around the following limitations:
+-- --  - Incremental refresh do not support `outer join` and
+-- --    `epoch_of_the_second_when_the_minute_slot_is_started` is not guaranteed to be the 
+-- --    same in both sub_views.
+-- --  - Incremental refresh do not support `union all` and `group by` in the same view
+-- CREATE MATERIALIZED VIEW sub_views.mv_01_auth_usage__checks__union as
+-- select 
+--   token_issued,
+--   token_issued_without_correlation_id,
+--   token_related_to_calls,
+--   0 as calls_associated_to_more_than_one_token,
+--   epoch_of_the_second_when_the_minute_slot_is_started
+-- from
+--   sub_views.mv_00_auth_usage__checks__calls_jwt_relation
+-- union all
+-- select 
+--   0 as token_issued,
+--   0 as token_issued_without_correlation_id,
+--   0 as token_related_to_calls,
+--   calls_associated_to_more_than_one_token,
+--   epoch_of_the_second_when_the_minute_slot_is_started
+-- from
+--   sub_views.mv_00_auth_usage__checks__calls_jwt_multi_relation
+-- ;

--- a/views/application/auth_server_usage/R__application_mv_02_auth_usage__grouped_checks.sql
+++ b/views/application/auth_server_usage/R__application_mv_02_auth_usage__grouped_checks.sql
@@ -5,24 +5,24 @@ GRANT USAGE ON SCHEMA views TO ${NAMESPACE}_quicksight_user;
 
 DROP MATERIALIZED VIEW IF EXISTS views.mv_02_auth_usage__grouped_checks CASCADE;
 
-CREATE MATERIALIZED VIEW views.mv_02_auth_usage__grouped_checks as
-select
-  -- Every token must be related to a call
-  -- We can't use outer join and check for relation null-ness;
-  -- we obtain the number of "not related" by difference "total - related".
-  sum( token_issued ) - sum( token_related_to_calls ) as token_without_related_call, 
-  -- Every token must have not null correlation_id
-  sum( token_issued_without_correlation_id ) as token_issued_without_correlation_id, 
-  -- Every call must be associated at no more than one tokens.
-  -- Can be weird but a "status 500 call" could be associated to a token.
-  sum( calls_associated_to_more_than_one_token ) as calls_associated_to_more_than_one_token,  
-  epoch_of_the_second_when_the_minute_slot_is_started,
-  timestamptz 'epoch' + epoch_of_the_second_when_the_minute_slot_is_started * interval '1 second' as minute_slot
-from
-  sub_views.mv_01_auth_usage__checks__union
-group by
-  epoch_of_the_second_when_the_minute_slot_is_started
-;
+-- CREATE MATERIALIZED VIEW views.mv_02_auth_usage__grouped_checks as
+-- select
+--   -- Every token must be related to a call
+--   -- We can't use outer join and check for relation null-ness;
+--   -- we obtain the number of "not related" by difference "total - related".
+--   sum( token_issued ) - sum( token_related_to_calls ) as token_without_related_call, 
+--   -- Every token must have not null correlation_id
+--   sum( token_issued_without_correlation_id ) as token_issued_without_correlation_id, 
+--   -- Every call must be associated at no more than one tokens.
+--   -- Can be weird but a "status 500 call" could be associated to a token.
+--   sum( calls_associated_to_more_than_one_token ) as calls_associated_to_more_than_one_token,  
+--   epoch_of_the_second_when_the_minute_slot_is_started,
+--   timestamptz 'epoch' + epoch_of_the_second_when_the_minute_slot_is_started * interval '1 second' as minute_slot
+-- from
+--   sub_views.mv_01_auth_usage__checks__union
+-- group by
+--   epoch_of_the_second_when_the_minute_slot_is_started
+-- ;
 
-GRANT SELECT ON TABLE views.mv_02_auth_usage__grouped_checks TO ${NAMESPACE}_quicksight_user;
+-- GRANT SELECT ON TABLE views.mv_02_auth_usage__grouped_checks TO ${NAMESPACE}_quicksight_user;
 

--- a/views/procedures/refresh_materialized_views/R__procedures_01_list_stale_materialized_views.sql
+++ b/views/procedures/refresh_materialized_views/R__procedures_01_list_stale_materialized_views.sql
@@ -138,7 +138,7 @@ BEGIN
       -- Only include views if they're in the first 2, or if total refresh time is under 7 minutes (420 seconds)
       ordinal <= 2 or coalesce(cumulative_refresh_time, 0) <= 420
     order by
-      last_refresh_start_time
+      last_refresh_start_time nulls first
   );
   
   GRANT SELECT ON list_need_refresh_views_results to ${NAMESPACE}_mv_refresher_user;

--- a/views/procedures/refresh_materialized_views/R__procedures_01_list_stale_materialized_views.sql
+++ b/views/procedures/refresh_materialized_views/R__procedures_01_list_stale_materialized_views.sql
@@ -135,7 +135,7 @@ BEGIN
     from
       views_to_refresh_enriched
     where
-      ordinal <= 2 or cumulative_refresh_time <= 420
+      ordinal <= 2 or coalesce(cumulative_refresh_time, 0) <= 420
     order by
       last_refresh_start_time
   );

--- a/views/procedures/refresh_materialized_views/R__procedures_01_list_stale_materialized_views.sql
+++ b/views/procedures/refresh_materialized_views/R__procedures_01_list_stale_materialized_views.sql
@@ -69,6 +69,10 @@ BEGIN
           trim(mv_name) as mv_name,
           start_time as refresh_start_time,
           end_time as refresh_end_time,
+          -- extract give null output for null input
+          extract(epoch from refresh_start_time) as refresh_start_time_epoch,
+          extract(epoch from refresh_end_time) as refresh_end_time_epoch,
+          refresh_end_time_epoch - refresh_start_time_epoch as refresh_time_seconds,
           ROW_NUMBER() over ( partition by database_name, schema_name, mv_name order by start_time desc ) as nr
         FROM
           SYS_MV_REFRESH_HISTORY
@@ -95,23 +99,45 @@ BEGIN
           mv_schema,
           mv_name,
           mv_level
+      ),
+      views_to_refresh_enriched as (
+        select
+	      v.mv_schema,
+	      v.mv_name,
+	      v.mv_level,
+	      v.incremental_refresh_not_supported,
+	      r.refresh_time_seconds,
+	      sum(r.refresh_time_seconds) 
+	        over ( 
+	          order by r.refresh_start_time 
+	          ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+	        ) 
+	        as cumulative_refresh_time,
+	      ROW_NUMBER() 
+	        over ( 
+	          order by r.refresh_start_time 
+	        ) 
+	        as ordinal,
+	      r.refresh_start_time as last_refresh_start_time,
+	      r.refresh_end_time as last_refresh_end_time,
+	      -- extract give null output for null input
+	      r.refresh_start_time_epoch as last_refresh_start_time_epoch,
+	      r.refresh_end_time_epoch as last_refresh_end_time_epoch,
+	      v.dist
+	    from
+	      views_to_refresh v
+	      left join last_refresh r on r.mv_schema  = v.mv_schema and r.mv_name  = v.mv_name
+	    where
+	      v.mv_level is not null
       )
     select
-      v.mv_schema,
-      v.mv_name,
-      v.mv_level,
-      v.incremental_refresh_not_supported,
-      r.refresh_start_time as last_refresh_start_time,
-      r.refresh_end_time as last_refresh_end_time,
-      -- extract give null output for null input
-      extract(epoch from r.refresh_start_time) as last_refresh_start_time_epoch,
-      extract(epoch from r.refresh_end_time) as last_refresh_end_time_epoch,
-      v.dist
+      *
     from
-      views_to_refresh v
-      left join last_refresh r on r.mv_schema  = v.mv_schema and r.mv_name  = v.mv_name
-      where
-        v.mv_level is not null
+      views_to_refresh_enriched
+    where
+      ordinal <= 2 or cumulative_refresh_time <= 420
+    order by
+      last_refresh_start_time
   );
   
   GRANT SELECT ON list_need_refresh_views_results to ${NAMESPACE}_mv_refresher_user;

--- a/views/procedures/refresh_materialized_views/R__procedures_01_list_stale_materialized_views.sql
+++ b/views/procedures/refresh_materialized_views/R__procedures_01_list_stale_materialized_views.sql
@@ -109,13 +109,13 @@ BEGIN
 	      r.refresh_time_seconds,
 	      sum(r.refresh_time_seconds) 
 	        over ( 
-	          order by r.refresh_start_time 
+	          order by r.refresh_start_time NULLS FIRST
 	          ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
 	        ) 
 	        as cumulative_refresh_time,
 	      ROW_NUMBER() 
 	        over ( 
-	          order by r.refresh_start_time 
+	          order by r.refresh_start_time NULLS FIRST
 	        ) 
 	        as ordinal,
 	      r.refresh_start_time as last_refresh_start_time,

--- a/views/procedures/refresh_materialized_views/R__procedures_01_list_stale_materialized_views.sql
+++ b/views/procedures/refresh_materialized_views/R__procedures_01_list_stale_materialized_views.sql
@@ -135,6 +135,7 @@ BEGIN
     from
       views_to_refresh_enriched
     where
+      -- Only include views if they're in the first 2, or if total refresh time is under 7 minutes (420 seconds)
       ordinal <= 2 or coalesce(cumulative_refresh_time, 0) <= 420
     order by
       last_refresh_start_time


### PR DESCRIPTION
Remove 4 non-essential materialized views used to check data during development and no more useful.

This pull request implements also a "best effort" refresh strategy for materialized views.
To avoid error in refresh lambda and restart refresh from level 0 we prefer conservatively estimate the cumulative refresh time of materialized views starting 
from the least recently refreshed.
Only materialized view refreshable in 7 minutes (but at least 2 views) are refreshed
each lambda execution.
